### PR TITLE
[+] GearmanClient::getPreparedNativeClient method

### DIFF
--- a/Service/GearmanClient.php
+++ b/Service/GearmanClient.php
@@ -93,6 +93,17 @@ class GearmanClient extends AbstractGearmanService
     }
 
     /**
+     * Returns \GearmanClient with filled servers info
+     * @return \GearmanClient
+     */
+    public function getPreparedNativeClient(): \GearmanClient
+    {
+        $client = new \GearmanClient();
+        $this->assignServers($client);
+        return $client;
+    }
+
+    /**
      * Init tasks structure
      *
      * @return GearmanClient self Object


### PR DESCRIPTION
Allows you to use native \GearmanClient class with server information filled in.